### PR TITLE
feat: Add class content download

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -427,11 +427,18 @@ impl CourseContentStream {
         let mut all_contents = Vec::new();
         for dom in doms {
             let dom = dom?;
+            let title_sel = Selector::parse("#pageTitleText > span").unwrap();
+            let title = dom
+                .select(&title_sel)
+                .next()
+                .context("course content title not found")?
+                .text()
+                .collect::<String>();
             let selector = Selector::parse("#content_listContainer > li").unwrap();
             let contents = dom
                 .select(&selector)
                 .filter_map(|li| {
-                    CourseContentData::from_element(li)
+                    CourseContentData::from_element(li, Some(title.clone()))
                         .inspect_err(|e| log::warn!("CourseContentData::from_element error: {e}"))
                         .ok()
                 })
@@ -491,6 +498,20 @@ impl CourseContent {
             None
         }
     }
+
+    pub fn into_ppt_opt(self) -> Option<CoursePPTHandle> {
+        if let CourseContentKind::Document = self.data.kind
+            && self.data.root_title.as_str() == "教学内容"
+        {
+            Some(CoursePPTHandle {
+                client: self.client,
+                course: self.course,
+                content: self.data,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -504,6 +525,7 @@ enum CourseContentKind {
 pub struct CourseContentData {
     id: String,
     title: String,
+    root_title: String,
     kind: CourseContentKind,
     has_link: bool,
     descriptions: Vec<String>,
@@ -533,7 +555,10 @@ fn collect_text(element: scraper::ElementRef) -> String {
 }
 
 impl CourseContentData {
-    fn from_element(el: scraper::ElementRef<'_>) -> anyhow::Result<Self> {
+    fn from_element(
+        el: scraper::ElementRef<'_>,
+        root_title: Option<String>,
+    ) -> anyhow::Result<Self> {
         anyhow::ensure!(el.value().name() == "li", "not a li element");
         let (img, title_div, detail_div) = el.child_elements().take(3).collect_tuple().unwrap();
 
@@ -552,6 +577,7 @@ impl CourseContentData {
             .to_owned();
 
         let title = title_div.text().collect::<String>().trim().to_owned();
+        let root_title = root_title.unwrap_or_else(|| "Unknown".to_owned());
         let has_link = title_div
             .select(&Selector::parse("a").unwrap())
             .next()
@@ -562,23 +588,39 @@ impl CourseContentData {
             .map(|p| collect_text(p).trim().to_owned())
             .collect::<Vec<_>>();
 
-        let attachments = detail_div
-            .select(&Selector::parse("ul.attachments > li > a").unwrap())
-            .map(|a| {
-                let text = a.text().collect::<String>();
-                let href = a.value().attr("href").unwrap();
-                let text = if let Some(text) = text.strip_prefix("\u{a0}") {
-                    text.to_owned()
-                } else {
-                    text
-                };
-                Ok((text, href.to_owned()))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
+        let attachments = {
+            let attachments = detail_div
+                .select(&Selector::parse("ul.attachments > li > a").unwrap())
+                .map(|a| {
+                    let text = a.text().collect::<String>();
+                    let href = a.value().attr("href").unwrap();
+                    let text = if let Some(text) = text.strip_prefix("\u{a0}") {
+                        text.to_owned()
+                    } else {
+                        text
+                    };
+                    Ok((text, href.to_owned()))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            let title_link = title_div
+                .select(&Selector::parse("a").unwrap())
+                .next()
+                .and_then(|a| {
+                    let text = a.text().collect::<String>();
+                    let href = a.value().attr("href")?;
+                    Some((text, href.to_owned()))
+                });
+            if attachments.is_empty() {
+                title_link.into_iter().collect()
+            } else {
+                attachments
+            }
+        };
 
         Ok(CourseContentData {
             id,
             title,
+            root_title,
             kind,
             has_link,
             descriptions,
@@ -846,6 +888,80 @@ impl CourseAssignment {
 
     pub fn deadline_raw(&self) -> Option<&str> {
         self.data.deadline.as_deref()
+    }
+
+    pub async fn download_attachment(
+        &self,
+        uri: &str,
+        dest: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        log::debug!("downloading attachment from https://course.pku.edu.cn{uri}");
+        let res = self.client.get_by_uri(uri).await?;
+        anyhow::ensure!(
+            res.status().as_u16() == 302,
+            "status not 302: {}",
+            res.status()
+        );
+
+        let loc = res
+            .headers()
+            .get("location")
+            .context("location header not found")?
+            .to_str()
+            .context("location header not str")?
+            .to_owned();
+
+        log::debug!("redicted to https://course.pku.edu.cn{loc}");
+        let res = self.client.get_by_uri(&loc).await?;
+        anyhow::ensure!(res.status().is_success(), "status not success");
+
+        let rbody = res.bytes().await?;
+        let r = compio::fs::write(dest, rbody).await;
+        compio::buf::buf_try!(@try r);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CoursePPTHandle {
+    client: Client,
+    course: Arc<CourseMeta>,
+    content: Arc<CourseContentData>,
+}
+
+impl CoursePPTHandle {
+    pub fn get(&self) -> anyhow::Result<CoursePPT> {
+        Ok(CoursePPT {
+            client: self.client.clone(),
+            content: self.content.clone(),
+        })
+    }
+
+    pub fn id(&self) -> String {
+        let mut hasher = std::hash::DefaultHasher::new();
+        self.course.id.hash(&mut hasher);
+        self.content.id.hash(&mut hasher);
+        let x = hasher.finish();
+        format!("{x:x}")
+    }
+}
+
+pub struct CoursePPT {
+    client: Client,
+    content: Arc<CourseContentData>,
+}
+
+impl CoursePPT {
+    pub fn title(&self) -> &str {
+        &self.content.title
+    }
+
+    pub fn descriptions(&self) -> &[String] {
+        &self.content.descriptions
+    }
+
+    pub fn attachments(&self) -> &[(String, String)] {
+        &self.content.attachments
     }
 
     pub async fn download_attachment(

--- a/src/cli/cmd_assignment.rs
+++ b/src/cli/cmd_assignment.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 
 use super::*;
 
-async fn get_contents(
+pub(crate) async fn get_contents(
     c: &api::Course,
     pb: indicatif::ProgressBar,
 ) -> anyhow::Result<Vec<api::CourseContent>> {

--- a/src/cli/cmd_ppt.rs
+++ b/src/cli/cmd_ppt.rs
@@ -273,6 +273,7 @@ pub async fn download(
     force: bool,
     cur_term: bool,
     overwrite: bool,
+    suffix_on_conflict: bool,
 ) -> anyhow::Result<()> {
     let items = fetch_ppts(force, cur_term).await?;
 
@@ -285,7 +286,7 @@ pub async fn download(
     };
 
     let sp = pbar::new_spinner();
-    download_data(sp, dir, &a.2, overwrite, false).await?;
+    download_data(sp, dir, &a.2, overwrite, suffix_on_conflict).await?;
 
     Ok(())
 }
@@ -295,6 +296,7 @@ pub async fn download_course(
     force: bool,
     cur_term: bool,
     overwrite: bool,
+    suffix_on_conflict: bool,
 ) -> anyhow::Result<()> {
     let items = fetch_ppts(force, cur_term).await?;
     let course = select_course_name(&items)?;
@@ -303,7 +305,7 @@ pub async fn download_course(
     for (_, _ppt_id, ppt) in selected.into_iter() {
         let sp = pbar::new_spinner();
         sp.set_message(format!("downloading '{}'", ppt.title()));
-        download_data(sp, dir, &ppt, overwrite, true).await?;
+        download_data(sp, dir, &ppt, overwrite, suffix_on_conflict).await?;
     }
 
     Ok(())

--- a/src/cli/cmd_ppt.rs
+++ b/src/cli/cmd_ppt.rs
@@ -1,0 +1,401 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+
+use super::cmd_assignment::get_contents;
+use super::*;
+
+async fn get_ppts(
+    c: &api::Course,
+    pb: indicatif::ProgressBar,
+) -> anyhow::Result<Vec<api::CoursePPTHandle>> {
+    let r = get_contents(c, pb)
+        .await?
+        .into_iter()
+        .filter_map(|c| c.into_ppt_opt())
+        .collect();
+    Ok(r)
+}
+
+async fn get_courses_and_ppts(
+    force: bool,
+    cur_term: bool,
+) -> anyhow::Result<Vec<(api::Course, Vec<(String, api::CoursePPT)>)>> {
+    let courses = load_courses(force, cur_term).await?;
+
+    // fetch each course concurrently
+    let m = indicatif::MultiProgress::new();
+    let pb = m.add(pbar::new(courses.len() as u64)).with_prefix("All");
+    let futs = courses.into_iter().map(async |c| -> anyhow::Result<_> {
+        let c = c.get().await.context("fetch course")?;
+        let assignments = get_ppts(
+            &c,
+            m.add(pbar::new(0).with_prefix(c.meta().name().to_owned())),
+        )
+        .await
+        .with_context(|| format!("fetch assignment handles of {}", c.meta().title()))?;
+
+        pb.inc_length(assignments.len() as u64);
+        let futs = assignments.into_iter().map(async |a| -> anyhow::Result<_> {
+            let id = a.id();
+            let r = a.get().context("fetch assignment")?;
+            pb.inc(1);
+            Ok((id, r))
+        });
+        let assignments = try_join_all(futs).await?;
+
+        pb.inc(1);
+        Ok((c, assignments))
+    });
+    let courses = try_join_all(futs).await?;
+    pb.finish_and_clear();
+    m.clear().unwrap();
+    drop(pb);
+    drop(m);
+
+    Ok(courses)
+}
+
+pub async fn list(force: bool, cur_term: bool) -> anyhow::Result<()> {
+    let courses = get_courses_and_ppts(force, cur_term).await?;
+
+    let all_ppts = courses
+        .iter()
+        .flat_map(|(c, assignments)| {
+            assignments
+                .iter()
+                .map(move |(id, a)| (c.to_owned(), id.to_owned(), a))
+        })
+        .collect::<Vec<_>>();
+
+    // prepare output statements
+    let mut outbuf = Vec::new();
+    let title = "PPT列表";
+    let total = all_ppts.len();
+    writeln!(outbuf, "{D}>{D:#} {B}{title} ({total}){B:#} {D}<{D:#}\n")?;
+
+    for (c, id, a) in all_ppts {
+        write_course_ppt(&mut outbuf, &id, &c, a).context("io error")?;
+    }
+
+    // write to stdout
+    buf_try!(@try fs::stdout().write_all(outbuf).await);
+
+    Ok(())
+}
+
+type PPTListItem = (Arc<api::Course>, String, api::CoursePPT);
+
+fn has_known_suffix(path: &std::path::Path) -> bool {
+    let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    matches!(
+        &ext.to_ascii_lowercase()[..],
+        "ppt" | "pptx" | "doc" | "docx" | "pdf"
+    )
+}
+
+fn detect_attachment_ext(path: &std::path::Path) -> anyhow::Result<Option<&'static str>> {
+    let data = std::fs::read(path)?;
+
+    if data.starts_with(b"%PDF-") {
+        return Ok(Some("pdf"));
+    }
+
+    const OLE_MAGIC: &[u8; 8] = b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1";
+    if data.starts_with(OLE_MAGIC) {
+        if data
+            .windows(b"PowerPoint Document".len())
+            .any(|w| w == b"PowerPoint Document")
+            || data
+                .windows(b"Current User".len())
+                .any(|w| w == b"Current User")
+        {
+            return Ok(Some("ppt"));
+        }
+        if data
+            .windows(b"WordDocument".len())
+            .any(|w| w == b"WordDocument")
+        {
+            return Ok(Some("doc"));
+        }
+        return Ok(None);
+    }
+
+    if data.starts_with(b"PK\x03\x04")
+        || data.starts_with(b"PK\x05\x06")
+        || data.starts_with(b"PK\x07\x08")
+    {
+        if data.windows(b"ppt/".len()).any(|w| w == b"ppt/") {
+            return Ok(Some("pptx"));
+        }
+        if data.windows(b"word/".len()).any(|w| w == b"word/") {
+            return Ok(Some("docx"));
+        }
+        return Ok(None);
+    }
+
+    Ok(None)
+}
+
+async fn fetch_ppts(force: bool, cur_term: bool) -> anyhow::Result<Vec<PPTListItem>> {
+    let courses = get_courses_and_ppts(force, cur_term).await?;
+
+    let all_assignments = courses
+        .into_iter()
+        .flat_map(|(c, assignments)| {
+            let c = Arc::new(c);
+            assignments
+                .into_iter()
+                .map(move |(id, a)| (c.clone(), id, a))
+        })
+        .collect::<Vec<_>>();
+
+    Ok(all_assignments)
+}
+
+async fn select_ppt(mut items: Vec<PPTListItem>) -> anyhow::Result<PPTListItem> {
+    if items.is_empty() {
+        anyhow::bail!("assignments not found");
+    }
+
+    let mut options = Vec::new();
+
+    for (idx, (c, id, a)) in items.iter().enumerate() {
+        let mut outbuf = Vec::new();
+        write!(outbuf, "[{}] ", idx + 1)?;
+        write_ppt_title_ln(&mut outbuf, id, c, a).context("io error")?;
+        options.push(String::from_utf8(outbuf).unwrap());
+    }
+
+    let s = inquire::Select::new("请选择要下载的作业", options).raw_prompt()?;
+    let idx = s.index;
+    let r = items.swap_remove(idx);
+
+    Ok(r)
+}
+
+fn select_course_name(items: &[PPTListItem]) -> anyhow::Result<String> {
+    if items.is_empty() {
+        anyhow::bail!("ppts not found");
+    }
+
+    let mut options = Vec::new();
+    for (course, _, _) in items {
+        let name = course.meta().name().to_owned();
+        if !options.contains(&name) {
+            options.push(name);
+        }
+    }
+
+    if options.is_empty() {
+        anyhow::bail!("courses not found");
+    }
+
+    let chosen = inquire::Select::new("请选择课程", options).prompt()?;
+    Ok(chosen)
+}
+
+fn sanitize_path_component(raw: &str) -> String {
+    let cleaned = raw
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect::<String>()
+        .trim()
+        .to_owned();
+
+    if cleaned.is_empty() {
+        "untitled".to_owned()
+    } else {
+        cleaned
+    }
+}
+
+fn next_available_path(path: &std::path::Path) -> std::path::PathBuf {
+    if !path.exists() {
+        return path.to_path_buf();
+    }
+
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("file");
+    let ext = path.extension().and_then(|s| s.to_str());
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new(""));
+
+    let mut i = 1usize;
+    loop {
+        let candidate_name = match ext {
+            Some(ext) if !ext.is_empty() => format!("{stem}({i}).{ext}"),
+            _ => format!("{stem}({i})"),
+        };
+        let candidate = parent.join(candidate_name);
+        if !candidate.exists() {
+            return candidate;
+        }
+        i += 1;
+    }
+}
+
+fn select_ppts_by_course(
+    items: Vec<PPTListItem>,
+    course_name: &str,
+) -> anyhow::Result<Vec<PPTListItem>> {
+    let exact = items
+        .iter()
+        .filter(|(c, _, _)| c.meta().name() == course_name)
+        .count();
+
+    if exact > 0 {
+        let selected = items
+            .into_iter()
+            .filter(|(c, _, _)| c.meta().name() == course_name)
+            .collect::<Vec<_>>();
+        return Ok(selected);
+    }
+
+    let selected = items
+        .into_iter()
+        .filter(|(c, _, _)| c.meta().name().contains(course_name))
+        .collect::<Vec<_>>();
+
+    if selected.is_empty() {
+        anyhow::bail!("no course matched: {course_name}");
+    }
+
+    Ok(selected)
+}
+
+pub async fn download(
+    id: Option<&str>,
+    dir: &std::path::Path,
+    force: bool,
+    cur_term: bool,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    let items = fetch_ppts(force, cur_term).await?;
+
+    let a = match id {
+        Some(id) => match items.into_iter().find(|x| x.1 == id) {
+            Some(r) => r,
+            None => anyhow::bail!("assignment with id {} not found", id),
+        },
+        None => select_ppt(items).await?,
+    };
+
+    let sp = pbar::new_spinner();
+    download_data(sp, dir, &a.2, overwrite, false).await?;
+
+    Ok(())
+}
+
+pub async fn download_course(
+    dir: &std::path::Path,
+    force: bool,
+    cur_term: bool,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    let items = fetch_ppts(force, cur_term).await?;
+    let course = select_course_name(&items)?;
+    let selected = select_ppts_by_course(items, &course)?;
+
+    for (_, _ppt_id, ppt) in selected.into_iter() {
+        let sp = pbar::new_spinner();
+        sp.set_message(format!("downloading '{}'", ppt.title()));
+        download_data(sp, dir, &ppt, overwrite, true).await?;
+    }
+
+    Ok(())
+}
+
+async fn download_data(
+    sp: pbar::AsyncSpinner,
+    dir: &std::path::Path,
+    a: &api::CoursePPT,
+    overwrite: bool,
+    suffix_on_conflict: bool,
+) -> anyhow::Result<()> {
+    if !dir.exists() {
+        compio::fs::create_dir_all(dir).await?;
+    }
+
+    let atts = a.attachments();
+    let tot = atts.len();
+    for (id, (name, uri)) in atts.iter().enumerate() {
+        let mut target = dir.join(sanitize_path_component(name));
+        if !overwrite && target.exists() && suffix_on_conflict {
+            target = next_available_path(&target);
+        } else if !overwrite && target.exists() {
+            sp.set_message(format!(
+                "[{}/{tot}] skipping existing attachment '{name}'...",
+                id + 1
+            ));
+            continue;
+        }
+
+        sp.set_message(format!(
+            "[{}/{tot}] downloading attachment '{name}'...",
+            id + 1
+        ));
+        a.download_attachment(uri, &target)
+            .await
+            .with_context(|| format!("download attachment '{name}'"))?;
+
+        if !has_known_suffix(&target)
+            && let Some(ext) = detect_attachment_ext(&target)
+                .with_context(|| format!("detect attachment type for '{name}'"))?
+        {
+            let mut renamed =
+                target.with_file_name(format!("{}.{ext}", sanitize_path_component(name)));
+            if !overwrite && renamed.exists() && suffix_on_conflict {
+                renamed = next_available_path(&renamed);
+            }
+            if overwrite || !renamed.exists() {
+                std::fs::rename(&target, &renamed)
+                    .with_context(|| format!("rename attachment '{name}' to add .{ext}"))?;
+            }
+        }
+    }
+
+    drop(sp);
+    println!("Done.");
+    Ok(())
+}
+
+fn write_ppt_title_ln(
+    buf: &mut Vec<u8>,
+    id: &str,
+    c: &api::Course,
+    a: &api::CoursePPT,
+) -> std::io::Result<()> {
+    write!(buf, "{BL}{B}{}{B:#}{BL:#} {D}>{D:#} ", c.meta().name())?;
+    write!(buf, "{BL}{B}{}{B:#}{BL:#}", a.title())?;
+    writeln!(buf, " {D}{id}{D:#}")?;
+    Ok(())
+}
+
+fn write_course_ppt(
+    buf: &mut Vec<u8>,
+    id: &str,
+    c: &api::Course,
+    a: &api::CoursePPT,
+) -> std::io::Result<()> {
+    write_ppt_title_ln(buf, id, c, a)?;
+
+    if !a.descriptions().is_empty() {
+        writeln!(buf)?;
+        for p in a.descriptions() {
+            writeln!(buf, "{p}")?;
+        }
+    }
+    if !a.attachments().is_empty() {
+        writeln!(buf)?;
+        for (name, _) in a.attachments() {
+            writeln!(buf, "{D}[附件]{D:#} {UL}{name}{UL:#}")?;
+        }
+    }
+    writeln!(buf)?;
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod cmd_assignment;
 #[cfg(feature = "bark")]
 mod cmd_bark;
+mod cmd_ppt;
 mod cmd_syllabus;
 mod cmd_video;
 mod pbar;
@@ -59,6 +60,17 @@ enum Commands {
 
         #[command(subcommand)]
         command: VideoCommands,
+    },
+
+    /// 获取课程 PPT 列表/下载 PPT
+    #[command(visible_alias("p"), arg_required_else_help(true))]
+    Ppt {
+        /// 强制刷新
+        #[arg(short, long, default_value = "false")]
+        force: bool,
+
+        #[command(subcommand)]
+        command: PptCommands,
     },
 
     /// 选课操作
@@ -133,6 +145,40 @@ enum VideoCommands {
         /// 文件下载目录 (支持相对路径)
         #[arg(short = 'o', long)]
         outdir: Option<std::path::PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum PptCommands {
+    /// 获取课程 PPT 列表
+    #[command(visible_alias("ls"))]
+    List {
+        /// 显示所有学期的 PPT
+        #[arg(long, default_value = "false")]
+        all_term: bool,
+    },
+
+    /// 下载 PPT 附件到指定目录
+    #[command(visible_alias("down"))]
+    Download {
+        /// (Optionl) PPT ID (可通过 `pku3b ppt list` 查看)
+        id: Option<String>,
+
+        /// 交互式选择课程并下载该课程的全部课程文件
+        #[arg(short, long, default_value = "false")]
+        course: bool,
+
+        /// 文件下载目录 (支持相对路径)
+        #[arg(short, long, default_value = ".")]
+        dir: std::path::PathBuf,
+
+        /// 在所有学期的课程文件范围中查找
+        #[arg(long, default_value = "false")]
+        all_term: bool,
+
+        /// 覆盖同名文件
+        #[arg(short, long, default_value = "false")]
+        overwrite: bool,
     },
 }
 
@@ -509,6 +555,25 @@ pub async fn start(cli: Cli) -> anyhow::Result<()> {
                     id,
                     all_term,
                 } => cmd_video::download(outdir.as_deref(), force, id, !all_term).await?,
+            },
+            Commands::Ppt { force, command } => match command {
+                PptCommands::List { all_term } => cmd_ppt::list(force, !all_term).await?,
+                PptCommands::Download {
+                    id,
+                    course,
+                    dir,
+                    all_term,
+                    overwrite,
+                } => {
+                    if course {
+                        if id.is_some() {
+                            anyhow::bail!("cannot use both ppt id and course name together");
+                        }
+                        cmd_ppt::download_course(&dir, force, !all_term, overwrite).await?
+                    } else {
+                        cmd_ppt::download(id.as_deref(), &dir, force, !all_term, overwrite).await?
+                    }
+                }
             },
             Commands::Syllabus { dual, command } => match command {
                 SyllabusCommands::Show => cmd_syllabus::show(dual).await?,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -179,6 +179,10 @@ enum PptCommands {
         /// 覆盖同名文件
         #[arg(short, long, default_value = "false")]
         overwrite: bool,
+
+        /// 遇到同名文件时自动添加递增数字后缀（如 file(1).pdf）
+        #[arg(long, default_value = "false")]
+        suffix_on_conflict: bool,
     },
 }
 
@@ -564,14 +568,30 @@ pub async fn start(cli: Cli) -> anyhow::Result<()> {
                     dir,
                     all_term,
                     overwrite,
+                    suffix_on_conflict,
                 } => {
                     if course {
                         if id.is_some() {
                             anyhow::bail!("cannot use both ppt id and course name together");
                         }
-                        cmd_ppt::download_course(&dir, force, !all_term, overwrite).await?
+                        cmd_ppt::download_course(
+                            &dir,
+                            force,
+                            !all_term,
+                            overwrite,
+                            suffix_on_conflict,
+                        )
+                        .await?
                     } else {
-                        cmd_ppt::download(id.as_deref(), &dir, force, !all_term, overwrite).await?
+                        cmd_ppt::download(
+                            id.as_deref(),
+                            &dir,
+                            force,
+                            !all_term,
+                            overwrite,
+                            suffix_on_conflict,
+                        )
+                        .await?
                     }
                 }
             },


### PR DESCRIPTION
# Description

Implement issue #17.

# Details

## Features that supported

- Show all the class content: `cargo run -- ppt list`/`cargo run -- p ls`. Also supports `--all-term` option.
- Download one document: `cargo run -- ppt download <id>`/`cargo run -- p down <id>`. Also supports interactive mode.
- Download all documents of one class: `cargo run -- ppt download --course`/`cargo run -- p down -c`. Only support interactive mode. And also supports `--all-term` option.
- Download to given directory: `cargo run -- ppt download <id> --dir <dest_dir>`/`cargo run -- p down <id> --dir <dest_dir>`/`cargo run -- ppt download --course --dir <dest_dir>`/`cargo run -- p down -c --dir <dest_dir>`.
- Not overwrite the file with same name. Thus, If you try to download the class document, for example, every week, the file that have been downloaded will not be downloaded again. This is default mode. Use `--overwrite` option can change this.
- Support index the file with same name in name's suffix. Use `--suffix-on-conflict` can open this feature.

## Features that not fully supported

- Only support `doc`/`docx`/`ppt`/`pptx`/`pdf`. I think this is enough for most of the situations.
- Note that in some special scenario (like the picture shows below), class document can't be detected correctly. But I think this is not common.

<img width="717" height="359" alt="image" src="https://github.com/user-attachments/assets/fd4c6e83-834d-4708-9e4e-da0432a1139c" />