### PR TITLE
fix: handle course titles without ':' or '(' gracefully (fixes #56)

### DIFF
--- a/src/api/blackboard.rs
+++ b/src/api/blackboard.rs
@@ -142,14 +142,19 @@ impl CourseMeta {
 
     /// Course Name (semester)
     pub fn title(&self) -> &str {
-        self.long_title.split_once(":").unwrap().1.trim()
+        self.long_title
+            .split_once(':')
+            .map(|(_, s)| s.trim())
+            .unwrap_or(self.long_title.trim())
     }
 
     /// Cousre Name
     pub fn name(&self) -> &str {
         let s = self.title();
-        let i = s.char_indices().rfind(|(_, c)| *c == '(').unwrap().0;
-        s.split_at(i).0.trim()
+        s.char_indices()
+            .rfind(|(_, c)| *c == '(')
+            .map(|(i, _)| s.split_at(i).0.trim())
+            .unwrap_or(s)
     }
 }
 


### PR DESCRIPTION
## 问题

closes #56。

在 `CourseMeta::title()` 和 `CourseMeta::name()` 方法中，代码假设课程的 `long_title` 一定满足 `ID: Name (semester)` 格式：

- `title()` 使用 `.split_once(":").unwrap()`，若标题不含 `:` 则 panic
- `name()` 使用 `.rfind('(').unwrap()`，若标题不含 `(` 则 panic

对于像「26春实验」这样格式特殊的课程名，两个 `unwrap()` 都会导致整个 `assignment list` 崩溃。

## 修复

将两处 `unwrap()` 替换为安全的 fallback 逻辑：

- `title()`：若无 `:`，则直接返回 `long_title` 本身（trim 后）
- `name()`：若无 `(`，则直接返回完整的 `title()` 字符串

这是最小改动，不影响正常格式课程的行为。