### PR TITLE
Add keyring secrets and course archive downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 /cache
 .DS_Store
+/downloads

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,19 +689,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -1760,24 +1747,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.3",
+ "console",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -1790,7 +1764,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63703cf9069b85dbe6fe26e1c5230d013dee99d3559cd3d02ba39e099ef7ab02"
 dependencies = [
- "indicatif 0.18.4",
+ "indicatif",
  "log",
 ]
 
@@ -2371,12 +2345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,7 +2587,7 @@ dependencies = [
  "futures-util",
  "http",
  "image",
- "indicatif 0.17.11",
+ "indicatif",
  "indicatif-log-bridge",
  "inquire",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +215,23 @@ name = "async-stream-impl"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -145,9 +262,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -169,9 +286,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -192,10 +309,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "blocking"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -238,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -361,7 +491,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb85cde3af21a2baaaa6eb40dada718d8ef2ac4a1f4acf671091dea13f3f43d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg_aliases",
  "compio-buf",
  "compio-log",
@@ -568,6 +698,18 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.2",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -836,6 +978,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1046,7 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -900,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -956,9 +1128,9 @@ checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -973,6 +1145,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1019,6 +1218,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1115,6 +1325,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1251,6 +1474,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1303,9 +1550,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1517,10 +1764,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1530,7 +1790,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63703cf9069b85dbe6fe26e1c5230d013dee99d3559cd3d02ba39e099ef7ab02"
 dependencies = [
- "indicatif",
+ "indicatif 0.18.4",
  "log",
 ]
 
@@ -1550,7 +1810,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "crossterm",
  "dyn-clone",
  "fxhash",
@@ -1595,14 +1855,31 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "linux-keyutils",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1642,6 +1919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,10 +1935,20 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -1691,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"
@@ -1718,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
 dependencies = [
  "aes",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cbc",
  "ecb",
  "encoding_rs",
@@ -1801,9 +2097,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1841,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1878,7 +2183,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1896,6 +2201,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.12.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1938,6 +2256,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,10 +2296,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
+name = "num-complex"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1975,6 +2326,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2032,7 +2394,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2074,6 +2436,22 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2184,6 +2562,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,10 +2619,11 @@ dependencies = [
  "futures-util",
  "http",
  "image",
- "indicatif",
+ "indicatif 0.17.11",
  "indicatif-log-bridge",
  "inquire",
  "itertools",
+ "keyring",
  "log",
  "lopdf",
  "m3u8-rs",
@@ -2318,7 +2708,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -2379,6 +2769,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -2443,7 +2834,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -2512,7 +2903,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2567,12 +2958,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.12.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2595,7 +3018,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -2655,15 +3078,26 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2741,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2821,9 +3255,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2853,6 +3287,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -2942,7 +3382,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3084,7 +3524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "libc",
- "mio 1.2.0",
+ "mio 1.2.1",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -3136,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -3174,7 +3614,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3247,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "tz-rs"
@@ -3270,11 +3722,22 @@ dependencies = [
 
 [[package]]
 name = "tzdb_data"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125a0a63c4bd75c73f61863463cb400db4b1aa5039b203b0ee1d628a7e3dabb2"
+checksum = "febaa995f6852367564e16c3369988b99d471d43ed12b1255b8d294661797f1c"
 dependencies = [
  "tz-rs",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3306,9 +3769,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3327,6 +3790,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "url"
@@ -3417,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3430,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3440,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3453,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3488,7 +3957,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3619,11 +4088,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3659,11 +4146,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3679,6 +4183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,6 +4199,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3703,10 +4219,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3721,6 +4249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3731,6 +4265,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3745,6 +4285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,6 +4301,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3838,7 +4390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap",
  "log",
  "serde",
@@ -3875,10 +4427,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "yoke"
-version = "0.8.2"
+name = "xdg-home"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3898,19 +4460,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.48"
+name = "zbus"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3943,6 +4561,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3996,4 +4628,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = { version = "0.22", optional = true }
 bytes = { version = "1.10", default-features = false }
 cbc = { version = "0.1.2", optional = true, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 compio = { version = "0.19", features = [
     "macros",
     "process",
@@ -50,6 +50,7 @@ inquire = { version = "0.7", features = [
     "macros",
 ], default-features = false }
 itertools = "0.14.0"
+keyring = { version = "3.6.3", optional = true }
 log = "0.4"
 lopdf = { version = "0.39.0", optional = true, default-features = false }
 m3u8-rs = { version = "6.0", optional = true }
@@ -89,6 +90,15 @@ video-download = ["m3u8-rs", "aes", "cbc"]
 autoelect = ["ttshitu"]
 ttshitu = ["dep:image", "dep:base64"]
 bark = ["dep:urlencoding"]
+
+# store secrets in the OS keyring instead of cfg.toml
+keyring = [
+    "dep:keyring",
+    "keyring/apple-native",
+    "keyring/windows-native",
+    "keyring/linux-native-sync-persistent",
+    "keyring/crypto-rust",
+]
 
 pdf = ["dep:lopdf", "dep:image"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ http = { version = "1.2.0", default-features = false }
 image = { version = "0.25", optional = true, features = [
     "jpeg",
 ], default-features = false }
-indicatif = "0.17"
+indicatif = "0.18"
 indicatif-log-bridge = "0.2.3"
 inquire = { version = "0.7", features = [
     "crossterm",

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ pku3b 支持通过 [Bark](https://apps.apple.com/cn/app/bark-customed-notificati
 - 📢 按 ID 查看公告详情: `pku3b announcement show <ID>`
 - 🎥 查看课程回放列表: `pku3b v ls`
 - 🎥 查看所有学期课程回放列表: `pku3b v ls --all-term`
-- ⏯️ 下载课程回放: `pku3b v down <ID>`: ID 请在课程回放列表中复制，该命令会将视频转换为 mp4 格式保存在执行命令时所在的目录下（如果要下载历史学期的课程回放，需要使用 `--all-term` 选项）。
+- ⏯️ 下载课程回放: `pku3b v down <ID>`: ID 请在课程回放列表中复制，该命令会将视频转换为 mp4 格式保存在执行命令时所在的目录下（如果要下载历史学期的课程回放，需要使用 `--all-term` 选项）。可用 `-o <DIR>` 指定保存目录。
+- ⏯️ 顺序下载某门课的全部课程回放: `pku3b v down-course <课程名关键字> -o <DIR>`: 若匹配到多门课程，会提示交互选择；文件名会使用课程名、回放时间和回放标题生成。
 - 📱 初始化 Bark 通知: `pku3b bark init` 或 `pku3b b init`
 - 📱 测试 Bark 通知: `pku3b bark test` 或 `pku3b b test`
 - 🧩 初始化 TT 识图账号密码: `pku3b ttshitu init`

--- a/src/api/blackboard.rs
+++ b/src/api/blackboard.rs
@@ -369,6 +369,10 @@ impl CourseMeta {
         &self.id
     }
 
+    pub fn long_title(&self) -> &str {
+        &self.long_title
+    }
+
     /// Course Name (semester)
     pub fn title(&self) -> &str {
         self.long_title

--- a/src/api/blackboard/video.rs
+++ b/src/api/blackboard/video.rs
@@ -360,10 +360,21 @@ impl CourseVideo {
         if let Some(key) = key {
             // sequence number may be used to construct IV
             let seq = (self.pl.media_sequence as usize + index) as u128;
-            bytes = self
-                .decrypt_segment(key, bytes, seq)
-                .await
-                .context("decrypt segment data")?;
+            bytes = match self.decrypt_segment(key, bytes, seq).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    log::warn!(
+                        "decrypt cached segment #{index} failed, retrying without cache: {e:#}"
+                    );
+                    let fresh_bytes = self
+                        ._download_segment(&seg_url)
+                        .await
+                        .context("redownload segment data")?;
+                    self.decrypt_segment(key, fresh_bytes, seq)
+                        .await
+                        .context("decrypt redownloaded segment data")?
+                }
+            };
         }
 
         Ok(bytes)

--- a/src/cli/cmd_archive.rs
+++ b/src/cli/cmd_archive.rs
@@ -1,0 +1,186 @@
+use anyhow::Context;
+
+use super::*;
+
+#[derive(clap::Args)]
+pub struct CommandArchive {
+    /// 课程标题关键字或课程 ID；匹配多门课程时会交互选择
+    course: String,
+
+    /// 归档输出目录
+    #[arg(short = 'o', long)]
+    outdir: std::path::PathBuf,
+
+    /// 归档板块，可用 all 或逗号分隔的 assignment,course-content,video
+    #[arg(long, default_value = "all", value_parser = parse_archive_sections)]
+    sections: ArchiveSections,
+
+    /// 在所有学期的课程范围中查找
+    #[arg(long, default_value = "false")]
+    all_term: bool,
+
+    /// 覆盖已存在文件；默认跳过已存在文件
+    #[arg(long, default_value = "false")]
+    overwrite: bool,
+
+    /// 强制刷新
+    #[arg(short, long, default_value = "false")]
+    force: bool,
+
+    /// 手机令牌码。当需要使用 OTP 登录，但未提供此参数时，将会从命令行交互式读取 OTP 码。
+    #[arg(long, default_value = "")]
+    otp_code: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ArchiveSections {
+    assignment: bool,
+    course_content: bool,
+    video: bool,
+}
+
+impl ArchiveSections {
+    fn all() -> Self {
+        Self {
+            assignment: true,
+            course_content: true,
+            video: true,
+        }
+    }
+
+    fn none() -> Self {
+        Self {
+            assignment: false,
+            course_content: false,
+            video: false,
+        }
+    }
+
+    fn is_empty(self) -> bool {
+        !self.assignment && !self.course_content && !self.video
+    }
+}
+
+pub async fn run(cmd: CommandArchive, ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
+    if cmd.sections.video {
+        #[cfg(not(feature = "video-download"))]
+        anyhow::bail!(
+            "`archive --sections video` requires building pku3b with the `video-download` feature"
+        );
+    }
+
+    let courses = load_courses(ctx, cmd.force, !cmd.all_term, cmd.otp_code).await?;
+    let selected = select_course_handle(courses, &cmd.course, "请选择要归档的课程")?;
+    let title_has_duplicates = selected.title_has_duplicates;
+
+    let sp = ctx.spinner();
+    sp.set_message("fetching course...");
+    let course = selected.handle.get().await.context("fetch course")?;
+    ctx.remove_spinner(sp);
+
+    let course_dir = course_archive_dir(&cmd.outdir, &course, title_has_duplicates);
+    fs::create_dir_all(&course_dir)
+        .await
+        .with_context(|| format!("create output directory {}", course_dir.display()))?;
+
+    println!(
+        "开始归档课程 {B}{}{B:#} 到 {}",
+        course.meta().long_title(),
+        course_dir.display()
+    );
+
+    if cmd.sections.assignment {
+        let outdir = course_dir.join("assignments");
+        cmd_assignment::archive_course_assignments(ctx, &course, &outdir, cmd.overwrite).await?;
+    }
+
+    if cmd.sections.course_content {
+        let outdir = course_dir.join("course-content");
+        cmd_course_content::archive_course_contents(ctx, &course, &outdir, cmd.overwrite).await?;
+    }
+
+    if cmd.sections.video {
+        #[cfg(feature = "video-download")]
+        {
+            let outdir = course_dir.join("videos");
+            cmd_video::archive_course_videos(ctx, &course, &outdir, cmd.overwrite).await?;
+        }
+    }
+
+    println!("课程归档完成: {}", course_dir.display());
+    Ok(())
+}
+
+fn course_archive_dir(
+    outdir: &std::path::Path,
+    course: &Course,
+    title_has_duplicates: bool,
+) -> std::path::PathBuf {
+    let mut dirname = sanitize_filename_part(course.meta().long_title());
+    if title_has_duplicates {
+        dirname = format!("{}_{}", dirname, sanitize_filename_part(course.meta().id()));
+    }
+    outdir.join(dirname)
+}
+
+fn parse_archive_sections(input: &str) -> Result<ArchiveSections, String> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("sections cannot be empty".to_owned());
+    }
+
+    let mut sections = ArchiveSections::none();
+    for part in input.split(',') {
+        let part = part.trim();
+        match part {
+            "all" => return Ok(ArchiveSections::all()),
+            "assignment" | "assignments" | "a" => sections.assignment = true,
+            "course-content" | "course_content" | "coursecontent" | "cc" => {
+                sections.course_content = true;
+            }
+            "video" | "videos" | "v" => sections.video = true,
+            "" => return Err("sections cannot contain an empty item".to_owned()),
+            unknown => {
+                return Err(format!(
+                    "unknown section '{unknown}', expected all, assignment, course-content, or video"
+                ));
+            }
+        }
+    }
+
+    if sections.is_empty() {
+        Err("at least one section must be selected".to_owned())
+    } else {
+        Ok(sections)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sections_all() {
+        assert_eq!(
+            parse_archive_sections("all").unwrap(),
+            ArchiveSections::all()
+        );
+    }
+
+    #[test]
+    fn parse_sections_subset() {
+        assert_eq!(
+            parse_archive_sections("assignment,course-content").unwrap(),
+            ArchiveSections {
+                assignment: true,
+                course_content: true,
+                video: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_sections_rejects_unknown() {
+        assert!(parse_archive_sections("assignment,grades").is_err());
+    }
+}

--- a/src/cli/cmd_assignment.rs
+++ b/src/cli/cmd_assignment.rs
@@ -318,6 +318,95 @@ async fn download_data(
     Ok(())
 }
 
+pub(super) async fn archive_course_assignments(
+    ctx: &CommandCtx<'_>,
+    course: &Course,
+    outdir: &std::path::Path,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    fs::create_dir_all(outdir)
+        .await
+        .with_context(|| format!("create output directory {}", outdir.display()))?;
+
+    let search_pb = ctx
+        .multi
+        .add(pbar::new(0).with_prefix(course.meta().name().to_owned()));
+    let handles = get_assignments(course, search_pb.clone())
+        .await
+        .with_context(|| format!("fetch assignments of {}", course.meta().title()))?;
+    ctx.multi.remove(&search_pb);
+
+    if handles.is_empty() {
+        println!("课程 {} 没有作业，跳过。", course.meta().title());
+        return Ok(());
+    }
+
+    let pb = ctx
+        .multi
+        .add(pbar::new(handles.len() as u64))
+        .with_prefix("assignments");
+    let mut assignments = Vec::new();
+    for handle in handles {
+        let id = handle.id();
+        let assignment = handle
+            .get()
+            .await
+            .with_context(|| format!("fetch assignment {}", id))?;
+        pb.inc(1);
+        assignments.push((id, assignment));
+    }
+    pb.finish_and_clear();
+    ctx.multi.remove(&pb);
+
+    assignments.sort_by_cached_key(|(_, a)| a.deadline());
+
+    println!(
+        "准备归档 {B}{}{B:#} 个作业到 {}",
+        assignments.len(),
+        outdir.display()
+    );
+
+    let total = assignments.len();
+    for (idx, (id, assignment)) in assignments.into_iter().enumerate() {
+        let dir = outdir.join(numbered_entry_dir_name(idx + 1, assignment.title(), &id));
+        fs::create_dir_all(&dir)
+            .await
+            .with_context(|| format!("create output directory {}", dir.display()))?;
+
+        write_description_file(
+            &dir.join("description.txt"),
+            assignment.descriptions(),
+            overwrite,
+        )
+        .await?;
+
+        let atts = assignment.attachments();
+        let tot = atts.len();
+        for (att_idx, (name, uri)) in atts.iter().enumerate() {
+            let filename = sanitize_filename_part(name);
+            let dest = dir.join(&filename);
+            if should_skip_existing(&dest, overwrite) {
+                continue;
+            }
+
+            println!(
+                "[作业 {}/{}][附件 {}/{}] 下载 {}",
+                idx + 1,
+                total,
+                att_idx + 1,
+                tot,
+                dest.display()
+            );
+            assignment
+                .download_attachment(uri, &dest)
+                .await
+                .with_context(|| format!("download attachment '{name}'"))?;
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn submit(
     ctx: &CommandCtx<'_>,
     id: Option<&str>,

--- a/src/cli/cmd_bark.rs
+++ b/src/cli/cmd_bark.rs
@@ -23,9 +23,8 @@ pub async fn run(cmd: CommandBark, ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn init(_ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
-    let cfg_path = utils::default_config_path();
-    let mut cfg = config::read_cfg(&cfg_path)
+async fn init(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
+    let mut cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -33,15 +32,14 @@ async fn init(_ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
 
     cfg.bark = Some(config::BarkConfig { token });
 
-    config::write_cfg(&cfg_path, &cfg).await?;
+    config::write_cfg(&ctx.config_path, &cfg).await?;
 
     println!("{GR}{B}Bark 通知令牌已更新{B:#}{GR:#}");
     Ok(())
 }
 
-async fn test(_ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(&cfg_path)
+async fn test(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 

--- a/src/cli/cmd_course_content.rs
+++ b/src/cli/cmd_course_content.rs
@@ -273,3 +273,96 @@ pub async fn download(
 
     Ok(())
 }
+
+pub(super) async fn archive_course_contents(
+    ctx: &CommandCtx<'_>,
+    course: &Course,
+    outdir: &std::path::Path,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    fs::create_dir_all(outdir)
+        .await
+        .with_context(|| format!("create output directory {}", outdir.display()))?;
+
+    let search_pb = ctx
+        .multi
+        .add(pbar::new(0).with_prefix(course.meta().name().to_owned()));
+    let contents = get_contents(course, search_pb.clone())
+        .await
+        .with_context(|| format!("fetch course contents of {}", course.meta().title()))?;
+    ctx.multi.remove(&search_pb);
+
+    if contents.is_empty() {
+        println!("课程 {} 没有课程内容，跳过。", course.meta().title());
+        return Ok(());
+    }
+
+    println!(
+        "准备归档 {B}{}{B:#} 个课程内容到 {}",
+        contents.len(),
+        outdir.display()
+    );
+
+    let total = contents.len();
+    for (idx, ct) in contents.into_iter().enumerate() {
+        let ccid = ct.ccid();
+        let ccid_str = ccid.to_string();
+        let dir = outdir.join(numbered_entry_dir_name(idx + 1, ct.title(), &ccid_str));
+        fs::create_dir_all(&dir)
+            .await
+            .with_context(|| format!("create output directory {}", dir.display()))?;
+
+        write_description_file(&dir.join("description.txt"), ct.descriptions(), overwrite).await?;
+
+        if matches!(ct.kind(), CourseContentKind::File) {
+            let uri = course
+                .client()
+                .bb_course_content_file_uri(ccid.course_id(), ccid.content_id())
+                .await?;
+            log::info!("File: {uri}");
+            let filename = uri.rsplit_once('/').unwrap().1;
+            let filename = percent_encoding::percent_decode(filename.as_bytes())
+                .decode_utf8_lossy()
+                .to_string();
+            let dest = dir.join(sanitize_filename_part(&filename));
+            if !should_skip_existing(&dest, overwrite) {
+                println!(
+                    "[课程内容 {}/{}] 下载文件 {}",
+                    idx + 1,
+                    total,
+                    dest.display()
+                );
+                course
+                    .client()
+                    .course_attachment_download(&uri, &dest, false)
+                    .await
+                    .with_context(|| format!("download file '{filename}'"))?;
+            }
+        }
+
+        let atts = ct.attachments();
+        let tot = atts.len();
+        for (att_idx, (name, uri)) in atts.iter().enumerate() {
+            let dest = dir.join(sanitize_filename_part(name));
+            if should_skip_existing(&dest, overwrite) {
+                continue;
+            }
+
+            println!(
+                "[课程内容 {}/{}][附件 {}/{}] 下载 {}",
+                idx + 1,
+                total,
+                att_idx + 1,
+                tot,
+                dest.display()
+            );
+            course
+                .client()
+                .course_attachment_download(uri, &dest, true)
+                .await
+                .with_context(|| format!("download attachment '{name}'"))?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/cmd_course_table.rs
+++ b/src/cli/cmd_course_table.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::config;
-use crate::utils;
 use anyhow::Context;
 use compio::buf::buf_try;
 use compio::fs;
@@ -34,8 +33,7 @@ pub async fn run(cmd: CommandCourseTable, ctx: &CommandCtx<'_>) -> anyhow::Resul
 
     let sp = ctx.spinner();
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(&cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 

--- a/src/cli/cmd_syllabus.rs
+++ b/src/cli/cmd_syllabus.rs
@@ -48,8 +48,7 @@ pub async fn show(ctx: &CommandCtx<'_>, dual: Option<DualDegree>) -> anyhow::Res
     let sp = ctx.spinner();
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -87,8 +86,7 @@ pub async fn set_autoelective(
     let sp = ctx.spinner();
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(&cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -119,7 +117,7 @@ pub async fn set_autoelective(
     });
 
     let items = items.to_owned();
-    config::write_cfg(&cfg_path, &cfg).await?;
+    config::write_cfg(&ctx.config_path, &cfg).await?;
 
     println!("\n{GR}{B}添加成功{B:#}，您现在的补退选课程为：");
     for c in items {
@@ -179,8 +177,7 @@ pub async fn unset_autoelective(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
     let sp = ctx.spinner();
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let mut cfg = config::read_cfg(&cfg_path)
+    let mut cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -194,7 +191,7 @@ pub async fn unset_autoelective(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
 
     items.remove(idx);
 
-    config::write_cfg(&cfg_path, &cfg).await?;
+    config::write_cfg(&ctx.config_path, &cfg).await?;
 
     println!("{B}移除成功{B:#}");
     Ok(())
@@ -235,8 +232,7 @@ pub async fn launch_autoelective(
     let sp = ctx.spinner();
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(&cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 

--- a/src/cli/cmd_thesis_lib.rs
+++ b/src/cli/cmd_thesis_lib.rs
@@ -50,8 +50,7 @@ async fn search(ctx: &CommandCtx<'_>, keyword: String) -> anyhow::Result<()> {
     let sp = ctx.spinner();
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -100,8 +99,7 @@ async fn download(
     let sp = ctx.spinner();
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 

--- a/src/cli/cmd_ttshitu.rs
+++ b/src/cli/cmd_ttshitu.rs
@@ -23,9 +23,8 @@ pub async fn run(cmd: CommandTtshitu, ctx: &CommandCtx<'_>) -> anyhow::Result<()
     Ok(())
 }
 
-async fn init(_ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
-    let cfg_path = utils::default_config_path();
-    let mut cfg = config::read_cfg(&cfg_path)
+async fn init(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
+    let mut cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -34,17 +33,16 @@ async fn init(_ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
 
     cfg.ttshitu = Some(config::TTShiTuConfig { username, password });
 
-    config::write_cfg(cfg_path, &cfg).await?;
+    config::write_cfg(&ctx.config_path, &cfg).await?;
 
     println!("TT 识图配置已更新");
     Ok(())
 }
 
-async fn test(_ctx: &CommandCtx<'_>, image_path: Option<String>) -> anyhow::Result<()> {
+async fn test(ctx: &CommandCtx<'_>, image_path: Option<String>) -> anyhow::Result<()> {
     let c = crate::http::Client::from_cyper(cyper::Client::new()?);
 
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
     let ttshitu_cfg = cfg.ttshitu.as_ref().context("ttshitu not configured")?;

--- a/src/cli/cmd_video.rs
+++ b/src/cli/cmd_video.rs
@@ -41,6 +41,22 @@ enum VideoCommands {
         #[arg(short = 'o', long)]
         outdir: Option<std::path::PathBuf>,
     },
+
+    /// 顺序下载匹配课程的全部课程回放视频
+    #[command(visible_alias("down-course"))]
+    #[cfg(feature = "video-download")]
+    DownloadCourse {
+        /// 课程标题关键字；匹配多门课程时会交互选择
+        course: String,
+
+        /// 在所有学期的课程范围中查找
+        #[arg(long, default_value = "false")]
+        all_term: bool,
+
+        /// 文件下载目录 (支持相对路径)
+        #[arg(short = 'o', long)]
+        outdir: Option<std::path::PathBuf>,
+    },
 }
 
 pub async fn run(cmd: CommandVideo, ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
@@ -57,6 +73,22 @@ pub async fn run(cmd: CommandVideo, ctx: &CommandCtx<'_>) -> anyhow::Result<()> 
                 outdir.as_deref(),
                 cmd.force,
                 id,
+                !all_term,
+                cmd.otp_code,
+            )
+            .await?
+        }
+        #[cfg(feature = "video-download")]
+        VideoCommands::DownloadCourse {
+            course,
+            outdir,
+            all_term,
+        } => {
+            download_course(
+                ctx,
+                outdir.as_deref(),
+                cmd.force,
+                &course,
                 !all_term,
                 cmd.otp_code,
             )
@@ -126,10 +158,7 @@ pub async fn download(
     cur_term: bool,
     otp_code: String,
 ) -> anyhow::Result<()> {
-    let outdir = outdir.unwrap_or(std::path::Path::new("."));
-    if !outdir.exists() {
-        anyhow::bail!("output directory {:?} not exists", outdir.display());
-    }
+    let outdir = prepare_video_outdir(outdir).await?;
 
     let (_, courses, sp) = load_client_courses(ctx, force, cur_term, otp_code).await?;
 
@@ -159,7 +188,104 @@ pub async fn download(
 
     ctx.remove_spinner(sp);
 
-    println!("下载课程回放：{} ({})", v.course_name(), v.meta().title());
+    download_course_video(ctx, &v, &id, &outdir).await?;
+
+    Ok(())
+}
+
+#[cfg(feature = "video-download")]
+pub async fn download_course(
+    ctx: &CommandCtx<'_>,
+    outdir: Option<&std::path::Path>,
+    force: bool,
+    course_query: &str,
+    cur_term: bool,
+    otp_code: String,
+) -> anyhow::Result<()> {
+    let outdir = prepare_video_outdir(outdir).await?;
+
+    let courses = load_courses(ctx, force, cur_term, otp_code).await?;
+    let mut matches = courses
+        .into_iter()
+        .filter(|c| c.id() == course_query || c.long_title().contains(course_query))
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        anyhow::bail!("course matching '{course_query}' not found");
+    }
+
+    let course = if matches.len() == 1 {
+        matches.swap_remove(0)
+    } else {
+        let options = matches
+            .iter()
+            .map(|c| format!("{} {}", c.long_title(), c.id()))
+            .collect::<Vec<_>>();
+        let selected = inquire::Select::new("请选择要下载回放的课程", options).raw_prompt()?;
+        matches.swap_remove(selected.index)
+    };
+
+    let sp = ctx.spinner();
+    sp.set_message("fetching course...");
+    let course = course.get().await.context("fetch course")?;
+
+    sp.set_message("fetching video list...");
+    let videos = course.get_video_list().await.context("fetch video list")?;
+    ctx.remove_spinner(sp);
+
+    if videos.is_empty() {
+        anyhow::bail!("course '{}' has no videos", course.meta().title());
+    }
+
+    println!(
+        "准备下载 {B}{}{B:#} 的 {B}{}{B:#} 个课程回放到 {}",
+        course.meta().title(),
+        videos.len(),
+        outdir.display()
+    );
+
+    let total = videos.len();
+    for (idx, video) in videos.into_iter().enumerate() {
+        let id = video.id();
+        println!("\n[{}/{}] {}", idx + 1, total, video.meta().title());
+        let video = video
+            .get()
+            .await
+            .with_context(|| format!("fetch video metadata for {}", id))?;
+        download_course_video(ctx, &video, &id, &outdir)
+            .await
+            .with_context(|| format!("download video {}", id))?;
+    }
+
+    println!("全部课程回放下载完成。");
+
+    Ok(())
+}
+
+#[cfg(feature = "video-download")]
+async fn prepare_video_outdir(
+    outdir: Option<&std::path::Path>,
+) -> anyhow::Result<std::path::PathBuf> {
+    let outdir = outdir.unwrap_or(std::path::Path::new("."));
+    fs::create_dir_all(outdir)
+        .await
+        .with_context(|| format!("create output directory {}", outdir.display()))?;
+    Ok(outdir.to_path_buf())
+}
+
+#[cfg(feature = "video-download")]
+async fn download_course_video(
+    ctx: &CommandCtx<'_>,
+    v: &CourseVideo,
+    id: &str,
+    outdir: &std::path::Path,
+) -> anyhow::Result<()> {
+    println!(
+        "下载课程回放：{} ({}, {})",
+        v.course_name(),
+        v.meta().title(),
+        v.meta().time()
+    );
 
     // prepare download dir
     let dir = utils::projectdir()
@@ -181,8 +307,7 @@ pub async fn download(
     let merged = dir.join("merged").with_extension("ts");
     merge_segments(ctx, &merged, &paths).await?;
 
-    let dest = format!("{}_{}.mp4", v.course_name(), v.meta().title());
-    let dest = outdir.join(&dest);
+    let dest = outdir.join(video_output_filename(v));
     log::info!("Merged segments to {}", merged.display());
     log::info!(
         r#"You may execute `ffmpeg -i "{}" -c copy "{}"` to convert it to mp4"#,
@@ -213,6 +338,37 @@ pub async fn download(
     }
 
     Ok(())
+}
+
+#[cfg(feature = "video-download")]
+fn video_output_filename(v: &CourseVideo) -> String {
+    let course = sanitize_filename_part(v.course_name());
+    let time = sanitize_filename_part(v.meta().time());
+    let title = sanitize_filename_part(v.meta().title());
+
+    let stem = if title.is_empty() || title == time {
+        format!("{course}_{time}")
+    } else {
+        format!("{course}_{time}_{title}")
+    };
+    format!("{stem}.mp4")
+}
+
+#[cfg(feature = "video-download")]
+fn sanitize_filename_part(s: &str) -> String {
+    let s = s
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '<' | '>' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
+            ':' => '-',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect::<String>();
+
+    let s = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if s.is_empty() { "_".to_owned() } else { s }
 }
 
 #[cfg(feature = "video-download")]

--- a/src/cli/cmd_video.rs
+++ b/src/cli/cmd_video.rs
@@ -188,7 +188,7 @@ pub async fn download(
 
     ctx.remove_spinner(sp);
 
-    download_course_video(ctx, &v, &id, &outdir).await?;
+    download_course_video(ctx, &v, &id, &outdir, true).await?;
 
     Ok(())
 }
@@ -204,31 +204,17 @@ pub async fn download_course(
 ) -> anyhow::Result<()> {
     let outdir = prepare_video_outdir(outdir).await?;
 
-    let courses = load_courses(ctx, force, cur_term, otp_code).await?;
-    let mut matches = courses
-        .into_iter()
-        .filter(|c| c.id() == course_query || c.long_title().contains(course_query))
-        .collect::<Vec<_>>();
-
-    if matches.is_empty() {
-        anyhow::bail!("course matching '{course_query}' not found");
-    }
-
-    let course = if matches.len() == 1 {
-        matches.swap_remove(0)
-    } else {
-        let options = matches
-            .iter()
-            .map(|c| format!("{} {}", c.long_title(), c.id()))
-            .collect::<Vec<_>>();
-        let selected = inquire::Select::new("请选择要下载回放的课程", options).raw_prompt()?;
-        matches.swap_remove(selected.index)
-    };
+    let course = select_course(
+        ctx,
+        force,
+        cur_term,
+        otp_code,
+        course_query,
+        "请选择要下载回放的课程",
+    )
+    .await?;
 
     let sp = ctx.spinner();
-    sp.set_message("fetching course...");
-    let course = course.get().await.context("fetch course")?;
-
     sp.set_message("fetching video list...");
     let videos = course.get_video_list().await.context("fetch video list")?;
     ctx.remove_spinner(sp);
@@ -252,12 +238,55 @@ pub async fn download_course(
             .get()
             .await
             .with_context(|| format!("fetch video metadata for {}", id))?;
-        download_course_video(ctx, &video, &id, &outdir)
+        download_course_video(ctx, &video, &id, &outdir, true)
             .await
             .with_context(|| format!("download video {}", id))?;
     }
 
     println!("全部课程回放下载完成。");
+
+    Ok(())
+}
+
+#[cfg(feature = "video-download")]
+pub(super) async fn archive_course_videos(
+    ctx: &CommandCtx<'_>,
+    course: &Course,
+    outdir: &std::path::Path,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    fs::create_dir_all(outdir)
+        .await
+        .with_context(|| format!("create output directory {}", outdir.display()))?;
+
+    let sp = ctx.spinner();
+    sp.set_message("fetching video list...");
+    let videos = course.get_video_list().await.context("fetch video list")?;
+    ctx.remove_spinner(sp);
+
+    if videos.is_empty() {
+        println!("课程 {} 没有课程回放，跳过。", course.meta().title());
+        return Ok(());
+    }
+
+    println!(
+        "准备归档 {B}{}{B:#} 个课程回放到 {}",
+        videos.len(),
+        outdir.display()
+    );
+
+    let total = videos.len();
+    for (idx, video) in videos.into_iter().enumerate() {
+        let id = video.id();
+        println!("\n[{}/{}] {}", idx + 1, total, video.meta().title());
+        let video = video
+            .get()
+            .await
+            .with_context(|| format!("fetch video metadata for {}", id))?;
+        download_course_video(ctx, &video, &id, outdir, overwrite)
+            .await
+            .with_context(|| format!("download video {}", id))?;
+    }
 
     Ok(())
 }
@@ -279,6 +308,7 @@ async fn download_course_video(
     v: &CourseVideo,
     id: &str,
     outdir: &std::path::Path,
+    overwrite: bool,
 ) -> anyhow::Result<()> {
     println!(
         "下载课程回放：{} ({}, {})",
@@ -287,11 +317,14 @@ async fn download_course_video(
         v.meta().time()
     );
 
+    let dest = outdir.join(video_output_filename(v));
+    if dest.exists() && !overwrite {
+        println!("跳过已存在课程回放: {}", dest.display());
+        return Ok(());
+    }
+
     // prepare download dir
-    let dir = utils::projectdir()
-        .cache_dir()
-        .join("video_download")
-        .join(&id);
+    let dir = utils::cache_dir().join("video_download").join(&id);
     fs::create_dir_all(&dir)
         .await
         .context("create dir failed")?;
@@ -307,7 +340,6 @@ async fn download_course_video(
     let merged = dir.join("merged").with_extension("ts");
     merge_segments(ctx, &merged, &paths).await?;
 
-    let dest = outdir.join(video_output_filename(v));
     log::info!("Merged segments to {}", merged.display());
     log::info!(
         r#"You may execute `ffmpeg -i "{}" -c copy "{}"` to convert it to mp4"#,
@@ -352,23 +384,6 @@ fn video_output_filename(v: &CourseVideo) -> String {
         format!("{course}_{time}_{title}")
     };
     format!("{stem}.mp4")
-}
-
-#[cfg(feature = "video-download")]
-fn sanitize_filename_part(s: &str) -> String {
-    let s = s
-        .trim()
-        .chars()
-        .map(|c| match c {
-            '<' | '>' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
-            ':' => '-',
-            c if c.is_control() => '_',
-            c => c,
-        })
-        .collect::<String>();
-
-    let s = s.split_whitespace().collect::<Vec<_>>().join(" ");
-    if s.is_empty() { "_".to_owned() } else { s }
 }
 
 #[cfg(feature = "video-download")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ mod pbar;
 /// Shared CLI context (global progress group from [`main`]).
 pub struct CommandCtx<'a> {
     pub multi: &'a MultiProgress,
+    pub config_path: std::path::PathBuf,
 }
 
 impl CommandCtx<'_> {
@@ -58,6 +59,10 @@ use utils::style::*;
     long_about = "a Better BlackBoard for PKUers. 北京大学教学网命令行工具 (️Win/Linux/Mac), 支持查看/提交作业、查看公告、下载课程回放."
 )]
 pub struct Cli {
+    /// 配置文件路径 (优先级高于 PKU3B_CONFIG)
+    #[arg(long, global = true, env = "PKU3B_CONFIG", value_name = "PATH")]
+    config: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -174,8 +179,7 @@ async fn load_blackboard(
     let client = build_client(enable_cache).await?;
 
     sp.set_message("reading config...");
-    let cfg_path = utils::default_config_path();
-    let cfg = config::read_cfg(cfg_path)
+    let cfg = config::read_cfg(&ctx.config_path)
         .await
         .context("read config file")?;
 
@@ -228,12 +232,12 @@ async fn load_courses(
 }
 
 async fn command_config(
+    ctx: &CommandCtx<'_>,
     attr: Option<config::ConfigAttrs>,
     value: Option<String>,
 ) -> anyhow::Result<()> {
-    let cfg_path = utils::default_config_path();
-    log::info!("Config path: '{}'", cfg_path.display());
-    let mut cfg = match config::read_cfg(&cfg_path).await {
+    log::info!("Config path: '{}'", ctx.config_path.display());
+    let mut cfg = match config::read_cfg(&ctx.config_path).await {
         Ok(r) => r,
         Err(e) => {
             anyhow::bail!("fail to read config: {e} (hint: run `pku3b init` to initialize it)")
@@ -241,14 +245,14 @@ async fn command_config(
     };
 
     let Some(attr) = attr else {
-        let s = toml::to_string_pretty(&cfg)?;
+        let s = toml::to_string_pretty(&cfg.redacted())?;
         println!("{s}");
         return Ok(());
     };
 
     if let Some(value) = value {
         cfg.update(attr, value)?;
-        config::write_cfg(&cfg_path, &cfg).await?;
+        config::write_cfg(&ctx.config_path, &cfg).await?;
     } else {
         let mut buf = Vec::new();
         cfg.display(attr, &mut buf)?;
@@ -257,9 +261,7 @@ async fn command_config(
     Ok(())
 }
 
-async fn command_init() -> anyhow::Result<()> {
-    let cfg_path = utils::default_config_path();
-
+async fn command_init(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
     let username = inquire::Text::new("输入 PKU IAAA 学号:").prompt()?;
     let password = inquire::Text::new("输入 PKU IAAA 密码:").prompt()?;
 
@@ -268,9 +270,10 @@ async fn command_init() -> anyhow::Result<()> {
         password,
         ttshitu: None,
         bark: None,
+        secret_backend: config::SecretBackend::Plaintext,
         auto_supplement: None,
     };
-    config::write_cfg(&cfg_path, &cfg).await?;
+    config::write_cfg(&ctx.config_path, &cfg).await?;
 
     println!("Configuration initialized.");
     Ok(())
@@ -318,11 +321,19 @@ async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
 }
 
 pub async fn start(cli: Cli, m: &MultiProgress) -> anyhow::Result<()> {
-    let ctx = CommandCtx { multi: m };
+    let config_path = cli
+        .config
+        .clone()
+        .unwrap_or_else(utils::default_config_path);
+    let ctx = CommandCtx {
+        multi: m,
+        config_path,
+    };
+
     if let Some(command) = cli.command {
         match command {
-            Commands::Config { attr, value } => command_config(attr, value).await?,
-            Commands::Init => command_init().await?,
+            Commands::Config { attr, value } => command_config(&ctx, attr, value).await?,
+            Commands::Init => command_init(&ctx).await?,
             Commands::Cache { command } => {
                 if let Some(command) = command {
                     match command {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 mod cmd_announcement;
+mod cmd_archive;
 mod cmd_assignment;
 #[cfg(feature = "bark")]
 mod cmd_bark;
@@ -63,12 +64,20 @@ pub struct Cli {
     #[arg(long, global = true, env = "PKU3B_CONFIG", value_name = "PATH")]
     config: Option<std::path::PathBuf>,
 
+    /// 缓存目录路径 (优先级高于 PKU3B_CACHE_DIR)
+    #[arg(long, global = true, env = "PKU3B_CACHE_DIR", value_name = "PATH")]
+    cache_dir: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
 enum Commands {
+    /// 一键归档整门课程的作业、课程内容和课程回放
+    #[command(visible_alias("ar"))]
+    Archive(cmd_archive::CommandArchive),
+
     /// 获取课程作业信息/下载附件/提交作业
     #[command(visible_alias("a"), arg_required_else_help(true))]
     Assignment(cmd_assignment::CommandAssignment),
@@ -231,6 +240,140 @@ async fn load_courses(
     Ok(r)
 }
 
+struct SelectedCourseHandle {
+    handle: CourseHandle,
+    title_has_duplicates: bool,
+}
+
+fn select_course_handle(
+    courses: Vec<CourseHandle>,
+    course_query: &str,
+    prompt: &str,
+) -> anyhow::Result<SelectedCourseHandle> {
+    let titles = courses
+        .iter()
+        .map(|c| c.long_title().to_owned())
+        .collect::<Vec<_>>();
+    let mut matches = courses
+        .into_iter()
+        .filter(|c| c.id() == course_query || c.long_title().contains(course_query))
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        anyhow::bail!("course matching '{course_query}' not found");
+    }
+
+    let handle = if matches.len() == 1 {
+        matches.swap_remove(0)
+    } else {
+        let options = matches
+            .iter()
+            .map(|c| format!("{} {}", c.long_title(), c.id()))
+            .collect::<Vec<_>>();
+        let selected = inquire::Select::new(prompt, options).raw_prompt()?;
+        matches.swap_remove(selected.index)
+    };
+    let title_has_duplicates = titles.iter().filter(|t| *t == handle.long_title()).count() > 1;
+
+    Ok(SelectedCourseHandle {
+        handle,
+        title_has_duplicates,
+    })
+}
+
+#[cfg(feature = "video-download")]
+async fn select_course(
+    ctx: &CommandCtx<'_>,
+    force: bool,
+    cur_term: bool,
+    otp_code: String,
+    course_query: &str,
+    prompt: &str,
+) -> anyhow::Result<Course> {
+    let courses = load_courses(ctx, force, cur_term, otp_code).await?;
+    let selected = select_course_handle(courses, course_query, prompt)?;
+
+    let sp = ctx.spinner();
+    sp.set_message("fetching course...");
+    let course = selected.handle.get().await.context("fetch course")?;
+    ctx.remove_spinner(sp);
+
+    Ok(course)
+}
+
+fn sanitize_filename_part(s: &str) -> String {
+    let s = s
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '<' | '>' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
+            ':' => '-',
+            c if c.is_whitespace() => ' ',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect::<String>();
+
+    let s = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if s.is_empty() { "_".to_owned() } else { s }
+}
+
+fn numbered_entry_dir_name(index: usize, title: &str, id: &str) -> String {
+    format!(
+        "{index:03}_{}_{}",
+        sanitize_filename_part(title),
+        sanitize_filename_part(id)
+    )
+}
+
+fn should_skip_existing(path: &std::path::Path, overwrite: bool) -> bool {
+    if path.exists() && !overwrite {
+        println!("跳过已存在文件: {}", path.display());
+        true
+    } else {
+        false
+    }
+}
+
+async fn write_description_file(
+    dest: &std::path::Path,
+    descriptions: &[String],
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    if descriptions.is_empty() || should_skip_existing(dest, overwrite) {
+        return Ok(());
+    }
+
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create output directory {}", parent.display()))?;
+    }
+
+    buf_try!(@try fs::write(dest, descriptions.join("\n")).await);
+    println!("写入描述: {}", dest.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_filename_part_replaces_path_separators_and_colons() {
+        assert_eq!(
+            sanitize_filename_part(r#" 课件: 第 1/2\3?讲* "#),
+            "课件- 第 1_2_3_讲_"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_part_collapses_whitespace_and_uses_placeholder() {
+        assert_eq!(sanitize_filename_part("a\t \n b"), "a b");
+        assert_eq!(sanitize_filename_part("   "), "_");
+    }
+}
+
 async fn command_config(
     ctx: &CommandCtx<'_>,
     attr: Option<config::ConfigAttrs>,
@@ -280,14 +423,14 @@ async fn command_init(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
 }
 
 async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
-    let dir = utils::projectdir();
-    log::info!("Cache dir: '{}'", dir.cache_dir().display());
+    let cache_dir = utils::cache_dir();
+    log::info!("Cache dir: '{}'", cache_dir.display());
     let sp = pbar::new_spinner();
     sp.set_message("scanning cache dir...");
 
     let mut total_bytes = 0;
-    if dir.cache_dir().exists() {
-        let d = std::fs::read_dir(dir.cache_dir())?;
+    if cache_dir.exists() {
+        let d = std::fs::read_dir(&cache_dir)?;
 
         let mut s = walkdir::walkdir(d, false);
         while let Some(e) = s.next().await {
@@ -306,7 +449,7 @@ async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
         }
 
         if !dry_run {
-            std::fs::remove_dir_all(dir.cache_dir())?;
+            std::fs::remove_dir_all(&cache_dir)?;
         }
     }
     drop(sp);
@@ -321,6 +464,10 @@ async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
 }
 
 pub async fn start(cli: Cli, m: &MultiProgress) -> anyhow::Result<()> {
+    if let Some(cache_dir) = cli.cache_dir.clone() {
+        utils::set_cache_dir(cache_dir);
+    }
+
     let config_path = cli
         .config
         .clone()
@@ -344,6 +491,7 @@ pub async fn start(cli: Cli, m: &MultiProgress) -> anyhow::Result<()> {
                     command_cache_clean(true).await?
                 }
             }
+            Commands::Archive(cmd) => cmd_archive::run(cmd, &ctx).await?,
             Commands::Assignment(cmd) => cmd_assignment::run(cmd, &ctx).await?,
             Commands::CourseContent(cmd) => cmd_course_content::run(cmd, &ctx).await?,
             Commands::CourseTable(cmd) => cmd_course_table::run(cmd, &ctx).await?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,27 @@
 use compio::fs;
+#[cfg(feature = "keyring")]
+use std::path::Path;
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg(feature = "keyring")]
+const KEYRING_SERVICE: &str = "org.sshwy.pku3b";
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SecretBackend {
+    #[default]
+    Plaintext,
+    Keyring,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Config {
     pub username: String,
+    #[serde(default)]
     pub password: String,
     pub ttshitu: Option<TTShiTuConfig>,
     pub bark: Option<BarkConfig>,
+    #[serde(default)]
+    pub secret_backend: SecretBackend,
 
     pub auto_supplement: Option<Vec<SupplementCourseConfig>>,
 }
@@ -18,18 +34,27 @@ pub struct SupplementCourseConfig {
     pub class_id: String,
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct TTShiTuConfig {
+    #[serde(default)]
     pub username: String,
+    #[serde(default)]
     pub password: String,
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct BarkConfig {
+    #[serde(default)]
     pub token: String,
 }
 
 impl Config {
+    pub fn redacted(&self) -> Self {
+        let mut cfg = self.clone();
+        cfg.redact_for_storage();
+        cfg
+    }
+
     pub fn display(&self, attr: ConfigAttrs, buf: &mut Vec<u8>) -> anyhow::Result<()> {
         use std::io::Write as _;
         match attr {
@@ -55,6 +80,13 @@ impl Config {
                 } else {
                     writeln!(buf, "<not set>")?
                 }
+            }
+            ConfigAttrs::SecretBackend => {
+                let backend = match self.secret_backend {
+                    SecretBackend::Plaintext => "plaintext",
+                    SecretBackend::Keyring => "keyring",
+                };
+                writeln!(buf, "{backend}")?
             }
         };
         Ok(())
@@ -85,9 +117,119 @@ impl Config {
                 }
             }
             ConfigAttrs::BarkToken => self.bark = Some(BarkConfig { token: value }),
+            ConfigAttrs::SecretBackend => {
+                self.secret_backend = match value.to_ascii_lowercase().as_str() {
+                    "plaintext" => SecretBackend::Plaintext,
+                    "keyring" => SecretBackend::Keyring,
+                    _ => anyhow::bail!(
+                        "invalid secret backend: {value} (expected: plaintext | keyring)"
+                    ),
+                };
+            }
         }
 
         Ok(())
+    }
+
+    #[cfg(feature = "keyring")]
+    fn keyring_account(path: &Path, key: &str) -> String {
+        let path = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        format!("config:{path}:{key}")
+    }
+
+    #[cfg(feature = "keyring")]
+    fn keyring_set(path: &Path, key: &str, value: &str) -> anyhow::Result<()> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, &Self::keyring_account(path, key))?;
+        entry.set_password(value)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "keyring")]
+    fn keyring_get(path: &Path, key: &str) -> anyhow::Result<Option<String>> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, &Self::keyring_account(path, key))?;
+        match entry.get_password() {
+            Ok(v) => Ok(Some(v)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[cfg(feature = "keyring")]
+    fn keyring_delete(path: &Path, key: &str) -> anyhow::Result<()> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, &Self::keyring_account(path, key))?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[cfg(feature = "keyring")]
+    fn sync_to_keyring(&self, path: &Path) -> anyhow::Result<()> {
+        Self::keyring_set(path, "password", &self.password)?;
+        if let Some(tt) = &self.ttshitu {
+            Self::keyring_set(path, "ttshitu.username", &tt.username)?;
+            Self::keyring_set(path, "ttshitu.password", &tt.password)?;
+        }
+        if let Some(bark) = &self.bark {
+            Self::keyring_set(path, "bark.token", &bark.token)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "keyring")]
+    fn fill_from_keyring(&mut self, path: &Path) -> anyhow::Result<()> {
+        if let Some(v) = Self::keyring_get(path, "password")? {
+            self.password = v;
+        }
+        if let Some(tt) = &mut self.ttshitu {
+            if let Some(v) = Self::keyring_get(path, "ttshitu.username")? {
+                tt.username = v;
+            }
+            if let Some(v) = Self::keyring_get(path, "ttshitu.password")? {
+                tt.password = v;
+            }
+        }
+        if let Some(bark) = &mut self.bark
+            && let Some(v) = Self::keyring_get(path, "bark.token")?
+        {
+            bark.token = v;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "keyring")]
+    fn remove_from_keyring(path: &Path) -> anyhow::Result<()> {
+        for key in [
+            "password",
+            "ttshitu.username",
+            "ttshitu.password",
+            "bark.token",
+        ] {
+            Self::keyring_delete(path, key)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(not(feature = "keyring"))]
+    fn ensure_keyring_enabled() -> anyhow::Result<()> {
+        anyhow::bail!(
+            "secret_backend is set to keyring, but this binary was built without the `keyring` feature"
+        )
+    }
+
+    fn redact_for_storage(&mut self) {
+        self.password.clear();
+        if let Some(tt) = &mut self.ttshitu {
+            tt.username.clear();
+            tt.password.clear();
+        }
+        if let Some(bark) = &mut self.bark {
+            bark.token.clear();
+        }
     }
 }
 
@@ -98,6 +240,7 @@ pub enum ConfigAttrs {
     TTShiTuUsername,
     TTShiTuPassword,
     BarkToken,
+    SecretBackend,
 }
 
 impl clap::ValueEnum for ConfigAttrs {
@@ -108,6 +251,7 @@ impl clap::ValueEnum for ConfigAttrs {
             Self::TTShiTuUsername,
             Self::TTShiTuPassword,
             Self::BarkToken,
+            Self::SecretBackend,
         ]
     }
 
@@ -118,6 +262,7 @@ impl clap::ValueEnum for ConfigAttrs {
             Self::TTShiTuUsername => Some(clap::builder::PossibleValue::new("ttshitu.username")),
             Self::TTShiTuPassword => Some(clap::builder::PossibleValue::new("ttshitu.password")),
             Self::BarkToken => Some(clap::builder::PossibleValue::new("bark.token")),
+            Self::SecretBackend => Some(clap::builder::PossibleValue::new("secret-backend")),
         }
     }
 }
@@ -142,6 +287,16 @@ pub async fn read_cfg(path: impl AsRef<std::path::Path>) -> anyhow::Result<Confi
     let buffer = fs::read(path).await?;
     let content = String::from_utf8(buffer)?; //.context("invalid UTF-8")?;
     let cfg: Config = toml::from_str(&content)?;
+    if matches!(cfg.secret_backend, SecretBackend::Keyring) {
+        #[cfg(feature = "keyring")]
+        {
+            let mut cfg = cfg;
+            cfg.fill_from_keyring(path)?;
+            return Ok(cfg);
+        }
+        #[cfg(not(feature = "keyring"))]
+        Config::ensure_keyring_enabled()?;
+    }
 
     Ok(cfg)
 }
@@ -155,7 +310,28 @@ pub async fn write_cfg(path: impl AsRef<std::path::Path>, cfg: &Config) -> anyho
         fs::create_dir_all(par).await?;
     }
 
-    let content = toml::to_string(cfg)?;
+    let cfg_to_write = if matches!(cfg.secret_backend, SecretBackend::Keyring) {
+        #[cfg(feature = "keyring")]
+        {
+            let mut cfg_to_write = cfg.clone();
+            cfg_to_write.sync_to_keyring(path)?;
+            cfg_to_write.redact_for_storage();
+            cfg_to_write
+        }
+        #[cfg(not(feature = "keyring"))]
+        {
+            Config::ensure_keyring_enabled()?;
+            unreachable!("ensure_keyring_enabled always returns an error")
+        }
+    } else {
+        #[cfg(feature = "keyring")]
+        {
+            Config::remove_from_keyring(path)?;
+        }
+        cfg.clone()
+    };
+
+    let content = toml::to_string(&cfg_to_write)?;
     fs::write(path, content).await.0?;
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,7 @@ pub fn projectdir() -> dirs::ProjectDirs {
 }
 
 pub fn default_config_path() -> std::path::PathBuf {
-    crate::utils::projectdir().config_dir().join("cfg.toml")
+    projectdir().config_dir().join("cfg.toml")
 }
 
 pub fn default_user_agent_data_path() -> std::path::PathBuf {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use compio::{buf::buf_try, fs, io::AsyncReadAtExt};
 
+static CACHE_DIR_OVERRIDE: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
 pub mod style {
     use clap::builder::styling::{AnsiColor, Color, Style};
 
@@ -23,8 +25,23 @@ pub fn default_config_path() -> std::path::PathBuf {
     projectdir().config_dir().join("cfg.toml")
 }
 
+pub fn set_cache_dir(path: std::path::PathBuf) {
+    let _ = CACHE_DIR_OVERRIDE.set(path);
+}
+
+pub fn cache_dir() -> std::path::PathBuf {
+    CACHE_DIR_OVERRIDE
+        .get()
+        .cloned()
+        .unwrap_or_else(|| projectdir().cache_dir().to_path_buf())
+}
+
+fn cache_tmp_path(path: &std::path::Path) -> std::path::PathBuf {
+    path.with_extension(format!("tmp-{}", std::process::id()))
+}
+
 pub fn default_user_agent_data_path() -> std::path::PathBuf {
-    projectdir().cache_dir().join("ua.json")
+    cache_dir().join("ua.json")
 }
 
 /// If the cache file exists and is not expired, return the deserialized content.
@@ -48,7 +65,7 @@ where
     };
     let name = format!("with_cache-{name_hash:x}");
 
-    let path = &projectdir().cache_dir().join(&name);
+    let path = &cache_dir().join(&name);
 
     if let Ok(f) = fs::File::open(path).await
         && let Some(ttl) = ttl
@@ -66,7 +83,9 @@ where
     let r = fut.await?;
     fs::create_dir_all(path.parent().unwrap()).await?;
     let buf = serde_json::to_vec(&r)?;
-    buf_try!(@try fs::write(path, buf).await);
+    let tmp_path = cache_tmp_path(path);
+    buf_try!(@try fs::write(&tmp_path, buf).await);
+    fs::rename(tmp_path, path).await?;
 
     Ok(r)
 }
@@ -87,7 +106,7 @@ where
     };
     let name = format!("with_cache_bytes-{name_hash:x}");
 
-    let path = &projectdir().cache_dir().join(&name);
+    let path = &cache_dir().join(&name);
 
     if let Ok(f) = fs::File::open(path).await
         && let Some(ttl) = ttl
@@ -101,7 +120,9 @@ where
 
     let r = fut.await?;
     fs::create_dir_all(path.parent().unwrap()).await?;
-    let (_, r) = buf_try!(@try fs::write(path, r).await);
+    let tmp_path = cache_tmp_path(path);
+    buf_try!(@try fs::write(&tmp_path, r.clone()).await);
+    fs::rename(tmp_path, path).await?;
 
     Ok(r)
 }


### PR DESCRIPTION
## Summary

This PR adds safer secret storage and expands course download workflows:

- Add an optional keyring-backed config backend so credentials can be stored outside plaintext TOML.
- Add course-level video replay downloading with ordered MP4 output.
- Add a top-level `pku3b archive` command for downloading assignment attachments, course-content files/attachments/descriptions, and replay videos into a structured local archive.
- Add `--cache-dir` / `PKU3B_CACHE_DIR` so large video caches can be placed outside the default user cache directory.

## Details

- `secret_backend = "keyring"` stores sensitive fields in the OS keyring and redacts them from the config file.
- `pku3b video download-course <COURSE> -o <DIR>` downloads all replay videos for a matched course.
- `pku3b archive <COURSE> -o <DIR> --sections all|assignment,course-content,video` archives selected course sections and skips existing files by default.
- Video cache writes are now atomic, and encrypted segment downloads retry with a fresh fetch if cached bytes are corrupt.

## Test Plan

- `cargo check`
- `cargo check --features keyring`
- `cargo check --no-default-features`
- `cargo test cli::`
- `cargo run --quiet -- archive --help`
- `cargo run --quiet -- --cache-dir ./cache/pku3b cache show`