### PR TITLE
Allow overriding the cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ pku3b --cache-dir /data/pku3b-cache video download <VIDEO_ID>
 PKU3B_CACHE_DIR=./cache/pku3b pku3b cache show
 ```
 
-命令行参数 `--cache-dir` 的优先级高于环境变量 `PKU3B_CACHE_DIR`。缓存写入会先写入临时文件再重命名，避免中断或磁盘空间不足时留下半截缓存文件；如果课程回放的已缓存加密分片解密失败，程序会自动重新拉取该分片。
+命令行参数 `--cache-dir` 的优先级高于环境变量 `PKU3B_CACHE_DIR`。
 
 ## Bark 通知功能 📱
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-      --config <PATH>  配置文件路径 (优先级高于 PKU3B_CONFIG) [env: PKU3B_CONFIG=]
-  -h, --help           Print help (see more with '--help')
-  -V, --version        Print version
+      --config <PATH>     配置文件路径 (优先级高于 PKU3B_CONFIG) [env: PKU3B_CONFIG=]
+      --cache-dir <PATH>  缓存目录路径 (优先级高于 PKU3B_CACHE_DIR) [env: PKU3B_CACHE_DIR=]
+  -h, --help            Print help (see more with '--help')
+  -V, --version         Print version
 ```
 
 ## Demo 🎬
@@ -200,6 +201,23 @@ pku3b config secret-backend plaintext
 ```
 
 如果当前配置使用了 `secret_backend = "keyring"`，但正在运行的 `pku3b` 没有启用 `keyring` feature，程序会提示需要使用支持 keyring 的构建。
+
+### 缓存目录
+
+`pku3b` 会把登录状态、接口缓存和课程回放下载过程中的临时分片保存到缓存目录中。默认缓存目录由操作系统决定；如果课程回放较大，或默认缓存目录所在磁盘空间不足，可以使用全局参数 `--cache-dir <PATH>` 指定新的缓存目录：
+
+```bash
+pku3b --cache-dir ./cache/pku3b cache show
+pku3b --cache-dir /data/pku3b-cache video download <VIDEO_ID>
+```
+
+也可以通过环境变量 `PKU3B_CACHE_DIR` 指定默认缓存目录：
+
+```bash
+PKU3B_CACHE_DIR=./cache/pku3b pku3b cache show
+```
+
+命令行参数 `--cache-dir` 的优先级高于环境变量 `PKU3B_CACHE_DIR`。缓存写入会先写入临时文件再重命名，避免中断或磁盘空间不足时留下半截缓存文件；如果课程回放的已缓存加密分片解密失败，程序会自动重新拉取该分片。
 
 ## Bark 通知功能 📱
 

--- a/src/api/blackboard/video.rs
+++ b/src/api/blackboard/video.rs
@@ -360,21 +360,10 @@ impl CourseVideo {
         if let Some(key) = key {
             // sequence number may be used to construct IV
             let seq = (self.pl.media_sequence as usize + index) as u128;
-            bytes = match self.decrypt_segment(key, bytes, seq).await {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    log::warn!(
-                        "decrypt cached segment #{index} failed, retrying without cache: {e:#}"
-                    );
-                    let fresh_bytes = self
-                        ._download_segment(&seg_url)
-                        .await
-                        .context("redownload segment data")?;
-                    self.decrypt_segment(key, fresh_bytes, seq)
-                        .await
-                        .context("decrypt redownloaded segment data")?
-                }
-            };
+            bytes = self
+                .decrypt_segment(key, bytes, seq)
+                .await
+                .context("decrypt segment data")?;
         }
 
         Ok(bytes)

--- a/src/api/blackboard/video.rs
+++ b/src/api/blackboard/video.rs
@@ -360,10 +360,21 @@ impl CourseVideo {
         if let Some(key) = key {
             // sequence number may be used to construct IV
             let seq = (self.pl.media_sequence as usize + index) as u128;
-            bytes = self
-                .decrypt_segment(key, bytes, seq)
-                .await
-                .context("decrypt segment data")?;
+            bytes = match self.decrypt_segment(key, bytes, seq).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    log::warn!(
+                        "decrypt cached segment #{index} failed, retrying without cache: {e:#}"
+                    );
+                    let fresh_bytes = self
+                        ._download_segment(&seg_url)
+                        .await
+                        .context("redownload segment data")?;
+                    self.decrypt_segment(key, fresh_bytes, seq)
+                        .await
+                        .context("decrypt redownloaded segment data")?
+                }
+            };
         }
 
         Ok(bytes)

--- a/src/cli/cmd_video.rs
+++ b/src/cli/cmd_video.rs
@@ -162,10 +162,7 @@ pub async fn download(
     println!("下载课程回放：{} ({})", v.course_name(), v.meta().title());
 
     // prepare download dir
-    let dir = utils::projectdir()
-        .cache_dir()
-        .join("video_download")
-        .join(&id);
+    let dir = utils::cache_dir().join("video_download").join(&id);
     fs::create_dir_all(&dir)
         .await
         .context("create dir failed")?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,6 +63,10 @@ pub struct Cli {
     #[arg(long, global = true, env = "PKU3B_CONFIG", value_name = "PATH")]
     config: Option<std::path::PathBuf>,
 
+    /// 缓存目录路径 (优先级高于 PKU3B_CACHE_DIR)
+    #[arg(long, global = true, env = "PKU3B_CACHE_DIR", value_name = "PATH")]
+    cache_dir: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -280,14 +284,14 @@ async fn command_init(ctx: &CommandCtx<'_>) -> anyhow::Result<()> {
 }
 
 async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
-    let dir = utils::projectdir();
-    log::info!("Cache dir: '{}'", dir.cache_dir().display());
+    let cache_dir = utils::cache_dir();
+    log::info!("Cache dir: '{}'", cache_dir.display());
     let sp = pbar::new_spinner();
     sp.set_message("scanning cache dir...");
 
     let mut total_bytes = 0;
-    if dir.cache_dir().exists() {
-        let d = std::fs::read_dir(dir.cache_dir())?;
+    if cache_dir.exists() {
+        let d = std::fs::read_dir(&cache_dir)?;
 
         let mut s = walkdir::walkdir(d, false);
         while let Some(e) = s.next().await {
@@ -306,7 +310,7 @@ async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
         }
 
         if !dry_run {
-            std::fs::remove_dir_all(dir.cache_dir())?;
+            std::fs::remove_dir_all(&cache_dir)?;
         }
     }
     drop(sp);
@@ -321,6 +325,10 @@ async fn command_cache_clean(dry_run: bool) -> anyhow::Result<()> {
 }
 
 pub async fn start(cli: Cli, m: &MultiProgress) -> anyhow::Result<()> {
+    if let Some(cache_dir) = cli.cache_dir.clone() {
+        utils::set_cache_dir(cache_dir);
+    }
+
     let config_path = cli
         .config
         .clone()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use compio::{buf::buf_try, fs, io::AsyncReadAtExt};
 
+static CACHE_DIR_OVERRIDE: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
 pub mod style {
     use clap::builder::styling::{AnsiColor, Color, Style};
 
@@ -23,8 +25,23 @@ pub fn default_config_path() -> std::path::PathBuf {
     crate::utils::projectdir().config_dir().join("cfg.toml")
 }
 
+pub fn set_cache_dir(path: std::path::PathBuf) {
+    let _ = CACHE_DIR_OVERRIDE.set(path);
+}
+
+pub fn cache_dir() -> std::path::PathBuf {
+    CACHE_DIR_OVERRIDE
+        .get()
+        .cloned()
+        .unwrap_or_else(|| projectdir().cache_dir().to_path_buf())
+}
+
+fn cache_tmp_path(path: &std::path::Path) -> std::path::PathBuf {
+    path.with_extension(format!("tmp-{}", std::process::id()))
+}
+
 pub fn default_user_agent_data_path() -> std::path::PathBuf {
-    projectdir().cache_dir().join("ua.json")
+    cache_dir().join("ua.json")
 }
 
 /// If the cache file exists and is not expired, return the deserialized content.
@@ -48,7 +65,7 @@ where
     };
     let name = format!("with_cache-{name_hash:x}");
 
-    let path = &projectdir().cache_dir().join(&name);
+    let path = &cache_dir().join(&name);
 
     if let Ok(f) = fs::File::open(path).await
         && let Some(ttl) = ttl
@@ -66,7 +83,9 @@ where
     let r = fut.await?;
     fs::create_dir_all(path.parent().unwrap()).await?;
     let buf = serde_json::to_vec(&r)?;
-    buf_try!(@try fs::write(path, buf).await);
+    let tmp_path = cache_tmp_path(path);
+    buf_try!(@try fs::write(&tmp_path, buf).await);
+    fs::rename(tmp_path, path).await?;
 
     Ok(r)
 }
@@ -87,7 +106,7 @@ where
     };
     let name = format!("with_cache_bytes-{name_hash:x}");
 
-    let path = &projectdir().cache_dir().join(&name);
+    let path = &cache_dir().join(&name);
 
     if let Ok(f) = fs::File::open(path).await
         && let Some(ttl) = ttl
@@ -101,7 +120,9 @@ where
 
     let r = fut.await?;
     fs::create_dir_all(path.parent().unwrap()).await?;
-    let (_, r) = buf_try!(@try fs::write(path, r).await);
+    let tmp_path = cache_tmp_path(path);
+    buf_try!(@try fs::write(&tmp_path, r.clone()).await);
+    fs::rename(tmp_path, path).await?;
 
     Ok(r)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,10 +36,6 @@ pub fn cache_dir() -> std::path::PathBuf {
         .unwrap_or_else(|| projectdir().cache_dir().to_path_buf())
 }
 
-fn cache_tmp_path(path: &std::path::Path) -> std::path::PathBuf {
-    path.with_extension(format!("tmp-{}", std::process::id()))
-}
-
 pub fn default_user_agent_data_path() -> std::path::PathBuf {
     cache_dir().join("ua.json")
 }
@@ -83,9 +79,7 @@ where
     let r = fut.await?;
     fs::create_dir_all(path.parent().unwrap()).await?;
     let buf = serde_json::to_vec(&r)?;
-    let tmp_path = cache_tmp_path(path);
-    buf_try!(@try fs::write(&tmp_path, buf).await);
-    fs::rename(tmp_path, path).await?;
+    buf_try!(@try fs::write(path, buf).await);
 
     Ok(r)
 }
@@ -120,9 +114,7 @@ where
 
     let r = fut.await?;
     fs::create_dir_all(path.parent().unwrap()).await?;
-    let tmp_path = cache_tmp_path(path);
-    buf_try!(@try fs::write(&tmp_path, r.clone()).await);
-    fs::rename(tmp_path, path).await?;
+    let (_, r) = buf_try!(@try fs::write(path, r).await);
 
     Ok(r)
 }


### PR DESCRIPTION
Summary
- Add global `--cache-dir` and `PKU3B_CACHE_DIR` support.
- Route user-agent restore data and generic cache helpers through `utils::cache_dir()`.
- Route video download temporary segment storage through the configured cache directory.
- Keep cache write reliability and video segment retry changes out of this PR so the cache-dir override remains reviewable on its own.

Notes
- Rebased on top of the latest `upstream/master`.
- Follow-up PRs will cover atomic cache writes and encrypted video segment cache retry separately.

Tests
- `cargo fmt --check`
- `cargo check`
- `cargo check --no-default-features`
- `cargo test cli::`
- `cargo run --quiet -- --cache-dir ./cache/pku3b cache show`
