### PR TITLE
Refresh cached video segment on decrypt failure

### DIFF
--- a/src/api/blackboard/video.rs
+++ b/src/api/blackboard/video.rs
@@ -1,7 +1,7 @@
 use super::{Client, Course, CourseMeta};
 use crate::api::low_level;
 use crate::qs;
-use crate::utils::{with_cache, with_cache_bytes};
+use crate::utils::{refresh_cache_bytes, with_cache, with_cache_bytes};
 use anyhow::Context;
 use cyper::IntoUrl;
 use scraper::Selector;
@@ -348,8 +348,9 @@ impl CourseVideo {
 
         // fetch maybe encrypted segment data
         let seg_url: String = self.pl_url.join(&seg.uri).context("join seg url")?.into();
+        let segment_cache_key = format!("CourseVideo::download_segment_{seg_url}");
         let mut bytes = with_cache_bytes(
-            &format!("CourseVideo::download_segment_{seg_url}"),
+            &segment_cache_key,
             self.client.download_artifact_ttl(),
             self._download_segment(&seg_url),
         )
@@ -360,10 +361,21 @@ impl CourseVideo {
         if let Some(key) = key {
             // sequence number may be used to construct IV
             let seq = (self.pl.media_sequence as usize + index) as u128;
-            bytes = self
-                .decrypt_segment(key, bytes, seq)
-                .await
-                .context("decrypt segment data")?;
+            bytes = match self.decrypt_segment(key, bytes, seq).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    log::warn!(
+                        "decrypt cached segment #{index} failed, refreshing cached bytes: {e:#}"
+                    );
+                    let fresh_bytes =
+                        refresh_cache_bytes(&segment_cache_key, self._download_segment(&seg_url))
+                            .await
+                            .context("refresh segment cache")?;
+                    self.decrypt_segment(key, fresh_bytes, seq)
+                        .await
+                        .context("decrypt refreshed segment data")?
+                }
+            };
         }
 
         Ok(bytes)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,29 +92,51 @@ pub async fn with_cache_bytes<F>(
 where
     F: std::future::Future<Output = anyhow::Result<bytes::Bytes>>,
 {
+    let cache_name = cache_bytes_name(name);
+    let path = cache_bytes_path(name);
+
+    if let Ok(f) = fs::File::open(&path).await
+        && let Some(ttl) = ttl
+        && f.metadata().await?.modified()?.elapsed()? < ttl
+    {
+        let r = f.read_to_end_at(Vec::new(), 0).await;
+        let (_, buf) = buf_try!(@try r);
+        log::trace!("cache hit: {cache_name}");
+        return Ok(bytes::Bytes::from(buf));
+    }
+
+    refresh_cache_bytes(name, fut).await
+}
+
+fn cache_bytes_name(name: &str) -> String {
     let name_hash = {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         name.hash(&mut hasher);
         hasher.finish()
     };
-    let name = format!("with_cache_bytes-{name_hash:x}");
 
-    let path = &cache_dir().join(&name);
+    format!("with_cache_bytes-{name_hash:x}")
+}
 
-    if let Ok(f) = fs::File::open(path).await
-        && let Some(ttl) = ttl
-        && f.metadata().await?.modified()?.elapsed()? < ttl
-    {
-        let r = f.read_to_end_at(Vec::new(), 0).await;
-        let (_, buf) = buf_try!(@try r);
-        log::trace!("cache hit: {name}");
-        return Ok(bytes::Bytes::from(buf));
-    }
+fn cache_bytes_path(name: &str) -> std::path::PathBuf {
+    cache_dir().join(cache_bytes_name(name))
+}
 
+pub async fn refresh_cache_bytes<F>(name: &str, fut: F) -> anyhow::Result<bytes::Bytes>
+where
+    F: std::future::Future<Output = anyhow::Result<bytes::Bytes>>,
+{
     let r = fut.await?;
-    fs::create_dir_all(path.parent().unwrap()).await?;
-    let (_, r) = buf_try!(@try fs::write(path, r).await);
+    write_cache_bytes(&cache_bytes_path(name), r).await
+}
 
-    Ok(r)
+async fn write_cache_bytes(
+    path: &std::path::Path,
+    bytes: bytes::Bytes,
+) -> anyhow::Result<bytes::Bytes> {
+    fs::create_dir_all(path.parent().unwrap()).await?;
+    let (_, bytes) = buf_try!(@try fs::write(path, bytes).await);
+
+    Ok(bytes)
 }


### PR DESCRIPTION
Summary
- Refresh encrypted video segment bytes when decrypting cached segment data fails.
- Replace the same bytes cache entry with freshly downloaded segment bytes before retrying decryption.
- Extract bytes-cache path/write helpers so video code reuses the existing cache key hashing rules instead of duplicating them.

Why
- A corrupted cached encrypted segment can make video downloads fail repeatedly, because every retry reads the same bad cache entry.
- Refreshing the same cache entry lets the next run recover as well.

Out of Scope
- Does not add configurable cache directories.
- Does not add atomic cache writes.

Tests
- `cargo fmt --check`
- `cargo check`
- `cargo check --features video-download`
